### PR TITLE
Custom alias file

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -120,6 +120,11 @@ alias chown='chown --preserve-root'
 alias chmod='chmod --preserve-root'
 alias chgrp='chgrp --preserve-root'
 
+# Load system specific alias file
+if [ -f ~/.zsh_aliases ]; then
+    source ~/.zsh_aliases
+fi
+
 # -------------------------------------------------------------------
 # FUNCTIONS
 # ------------------------------------------------------------------- 


### PR DESCRIPTION
When a `.zsh_aliases` file is placed in the `$HOME` directory is placed, this will be loaded. This can be used to customize per system.